### PR TITLE
Disable ignoring build errors

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,10 +3,10 @@ import type {NextConfig} from 'next';
 const nextConfig: NextConfig = {
   /* config options here */
   typescript: {
-    ignoreBuildErrors: true,
+    ignoreBuildErrors: false,
   },
   eslint: {
-    ignoreDuringBuilds: true,
+    ignoreDuringBuilds: false,
   },
   images: {
     remotePatterns: [


### PR DESCRIPTION
## Summary
- enforce build-time checks by disabling `ignoreBuildErrors` and `ignoreDuringBuilds`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(prompted for ESLint setup; cancelled)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6891e8422b68832fbee58beb815f5bf5