### PR TITLE
feat: add robust serial and config error handling

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain } = require('electron');
+const { app, BrowserWindow, ipcMain, dialog } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const isDev = require('electron-is-dev');
@@ -41,6 +41,7 @@ app.whenReady().then(() => {
       console.error('Failed to load config:', err);
       // 더 안정적인 기본값으로 설정
       appConfig = { serial: { baudRate: 9600 }, valveMappings: {} };
+      dialog.showErrorBox('Configuration Error', 'Failed to load configuration file. Using default settings.');
   }
   createWindow();
 });
@@ -108,6 +109,7 @@ ipcMain.handle('get-serial-ports', async () => {
     return ports.map(p => p.path);
   } catch (error) {
     console.error('Failed to list serial ports:', error);
+    mainWindow?.webContents.send('serial-error', 'Failed to list serial ports.');
     return [];
   }
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -103,17 +103,27 @@ export default function Home() {
 
   useEffect(() => {
     const getPorts = async () => {
-      const ports = await window.electronAPI.getSerialPorts();
-      setSerialPorts(ports);
-      if (ports.length > 0) {
-        setSelectedPort(ports[0]);
+      try {
+        const ports = await window.electronAPI.getSerialPorts();
+        setSerialPorts(ports);
+        if (ports.length > 0) {
+          setSelectedPort(ports[0]);
+        }
+      } catch (error) {
+        console.error(error);
+        toast({ title: "Connection Error", description: "Failed to list serial ports.", variant: "destructive" });
       }
     };
     getPorts();
 
     const loadConfig = async () => {
-      const cfg = await window.electronAPI.getConfig();
-      setAppConfig(cfg);
+      try {
+        const cfg = await window.electronAPI.getConfig();
+        setAppConfig(cfg);
+      } catch (error) {
+        console.error(error);
+        toast({ title: "Configuration Error", description: "Failed to load configuration.", variant: "destructive" });
+      }
     };
     loadConfig();
 


### PR DESCRIPTION
## Summary
- guard serial-port and config loading in renderer with try/catch and user-facing toasts
- alert user if config file fails to load in main process and propagate serial port listing failures

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive ESLint config prompt, requires manual setup)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68933cf7196c832f91a8eb417f7a8d75