### PR TITLE
fix: clean up IPC listeners to prevent leaks

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -21,5 +21,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   startLogging: () => ipcRenderer.send('start-logging'),
   stopLogging: () => ipcRenderer.send('stop-logging'),
   getConfig: () => ipcRenderer.invoke('get-config'),
-  onLogCreationFailed: (callback) => ipcRenderer.on('log-creation-failed', (_event, value) => callback(value)),
+  onLogCreationFailed: (callback) => {
+    const listener = (_event, value) => callback(value);
+    ipcRenderer.on('log-creation-failed', listener);
+    return () => ipcRenderer.removeListener('log-creation-failed', listener);
+  },
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -75,9 +75,13 @@ export default function Home() {
   }, []);
 
   useEffect(() => {
-    window.electronAPI.onLogCreationFailed(() => {
+    const cleanup = window.electronAPI.onLogCreationFailed(() => {
       toast({ title: 'Logging Error', description: 'Failed to create log file.', variant: 'destructive' });
     });
+
+    return () => {
+      cleanup();
+    };
   }, [toast]);
 
   const handleLoggingToggle = () => {

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -16,7 +16,7 @@ declare global {
       startLogging: () => void;
       stopLogging: () => void;
       getConfig: () => Promise<import('./index').AppConfig>;
-      onLogCreationFailed: (callback: (error: string) => void) => void;
+      onLogCreationFailed: (callback: (error: string) => void) => () => void;
     };
   }
 }


### PR DESCRIPTION
## Summary
- return cleanup function from `onLogCreationFailed` in the preload script
- expose cleanup in type definitions and call it in the page component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: asks to configure ESLint)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68934e4cf87c832fab31a93b35cf0881