### PR TITLE
feat: add IPC response for serial commands

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -4,7 +4,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getSerialPorts: () => ipcRenderer.invoke('get-serial-ports'),
   connectSerial: (portName) => ipcRenderer.invoke('connect-serial', portName),
   disconnectSerial: () => ipcRenderer.invoke('disconnect-serial'),
-  sendToSerial: (data) => ipcRenderer.send('send-to-serial', data),
+  sendToSerial: (data) => ipcRenderer.invoke('send-to-serial', data),
   onSerialData: (callback) => {
     const listener = (_event, value) => callback(value);
     ipcRenderer.on('serial-data', listener);

--- a/src/hooks/useSequenceManager.ts
+++ b/src/hooks/useSequenceManager.ts
@@ -4,7 +4,7 @@ import { useToast } from '@/hooks/use-toast';
 interface SequenceStep {
   message: string;
   delay: number;
-  action?: () => void;
+  action?: () => void | Promise<void>;
 }
 
 export interface SequenceManagerApi {
@@ -14,7 +14,7 @@ export interface SequenceManagerApi {
   addLog: (message: string) => void;
 }
 
-export function useSequenceManager(sendCommand: (cmd: string) => void): SequenceManagerApi {
+export function useSequenceManager(sendCommand: (cmd: string) => Promise<void>): SequenceManagerApi {
   const { toast } = useToast();
   const [sequenceLogs, setSequenceLogs] = useState<string[]>(['System standby. Select a sequence to begin.']);
   const [activeSequence, setActiveSequence] = useState<string | null>(null);

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -7,7 +7,7 @@ declare global {
       getSerialPorts: () => Promise<string[]>;
       connectSerial: (portName: string) => Promise<boolean>;
       disconnectSerial: () => Promise<boolean>;
-      sendToSerial: (data: string) => void;
+      sendToSerial: (data: string) => Promise<boolean>;
       onSerialData: (callback: (data: string) => void) => () => void;
       onSerialError: (callback: (error: string) => void) => () => void;
       zoomIn: () => void;


### PR DESCRIPTION
## Summary
- switch serial send IPC to invoke/handle with success return
- await sendToSerial in React hook and report failures
- update types and sequence manager for async command API

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68934fb7f5bc832f95efa64ad4823fc9