### PR TITLE
Build Electron files before running dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 
 # production
 /build
+/dist
 
 # misc
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "rebuild": "electron-rebuild -f -w serialport"
+    "rebuild": "electron-rebuild -f -w serialport",
+    "predev": "tsc -p tsconfig.electron.json && node -e \"require('fs').copyFileSync('config.json','dist/config.json')\"",
+    "prebuild": "tsc -p tsconfig.electron.json && node -e \"require('fs').copyFileSync('config.json','dist/config.json')\""
   },
   "dependencies": {
     "@hookform/resolvers": "^4.1.3",

--- a/tsconfig.electron.json
+++ b/tsconfig.electron.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./dist",
+    "module": "commonjs",
+    "moduleResolution": "node"
+  },
+  "include": ["main.ts", "preload.ts", "main/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- compile Electron main & preload files before running `npm run dev`
- add dedicated TypeScript config for Electron build
- ignore generated `dist` artifacts

## Testing
- `npm run predev`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68936b8430e0832fa9e3098b84a4a3c2