### PR TITLE
Fix valve state updates and configuration safety

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -18,6 +18,8 @@ class MainApp {
       await this.configManager.load(configPath);
     } catch (err) {
       dialog.showErrorBox('Configuration Error', 'Failed to load configuration file.');
+      app.quit();
+      return;
     }
     await app.whenReady();
     this.createWindow();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,7 +30,7 @@ export default function Home() {
   } = useSerialManager();
 
   const { sequenceLogs, activeSequence, handleSequence, addLog } = useSequenceManager((cmd) =>
-    sendCommand({ type: 'RAW', payload: cmd })
+    sendCommand({ type: 'RAW', payload: cmd }).then(() => {})
   );
 
   const [isLogging, setIsLogging] = useState(false);

--- a/src/components/dashboard/valve-display.tsx
+++ b/src/components/dashboard/valve-display.tsx
@@ -8,7 +8,10 @@ import { DashboardItem } from './dashboard-item';
 
 interface ValveDisplayProps {
   valve: Valve;
-  onValveChange: (valveId: number, targetState: 'OPEN' | 'CLOSED') => void;
+  onValveChange: (
+    valveId: number,
+    targetState: 'OPEN' | 'CLOSED'
+  ) => Promise<void>;
 }
 
 const ValveIcon: React.FC<{ state: ValveState }> = ({ state }) => {
@@ -79,7 +82,9 @@ const ValveDisplayComponent: React.FC<ValveDisplayProps> = ({ valve, onValveChan
         <Button
           size="sm"
           className="flex-1 h-8 text-xs"
-          onClick={() => onValveChange(valve.id, 'OPEN')}
+          onClick={() => {
+            void onValveChange(valve.id, 'OPEN');
+          }}
           disabled={isTransitioning || valve.state === 'OPEN'}
         >
           Open
@@ -88,7 +93,9 @@ const ValveDisplayComponent: React.FC<ValveDisplayProps> = ({ valve, onValveChan
           size="sm"
           className="flex-1 h-8 text-xs"
           variant="outline"
-          onClick={() => onValveChange(valve.id, 'CLOSED')}
+          onClick={() => {
+            void onValveChange(valve.id, 'CLOSED');
+          }}
           disabled={isTransitioning || valve.state === 'CLOSED'}
         >
           Close

--- a/src/hooks/useSensorData.ts
+++ b/src/hooks/useSensorData.ts
@@ -11,7 +11,7 @@ export interface SensorDataApi {
 
 export function useSensorData(
   maxPoints: number,
-  pressureLimit: number,
+  pressureLimit: number | null,
   onEmergency: () => void,
   updateValves: (updates: Partial<Record<number, Partial<Valve>>>) => void
 ): SensorDataApi {
@@ -31,7 +31,10 @@ export function useSensorData(
         setSensorData(updated);
         sensorRef.current = updated;
         setChartData((prev) => [...prev, updated].slice(-maxPoints));
-        if (exceedsPressureLimit(updated, pressureLimit)) {
+        if (
+          pressureLimit !== null &&
+          exceedsPressureLimit(updated, pressureLimit)
+        ) {
           onEmergency();
         }
       }

--- a/src/hooks/useValveControl.ts
+++ b/src/hooks/useValveControl.ts
@@ -5,18 +5,18 @@ import { ValveCommandType } from '@shared/types/ipc';
 
 export interface ValveControlApi {
   valves: Valve[];
-  handleValveChange: (id: number, targetState: 'OPEN' | 'CLOSED') => void;
+  handleValveChange: (id: number, targetState: 'OPEN' | 'CLOSED') => Promise<void>;
   setValves: Dispatch<SetStateAction<Valve[]>>;
 }
 
 export function useValveControl(
-  sendCommand: (cmd: SerialCommand) => Promise<void>,
+  sendCommand: (cmd: SerialCommand) => Promise<boolean>,
   config?: AppConfig
 ): ValveControlApi {
   const [valves, setValves] = useState<Valve[]>(config?.initialValves ?? []);
 
   const handleValveChange = useCallback(
-    (valveId: number, targetState: 'OPEN' | 'CLOSED') => {
+    async (valveId: number, targetState: 'OPEN' | 'CLOSED') => {
       if (!config) return;
       const valve = valves.find((v) => v.id === valveId);
       if (!valve) return;
@@ -27,9 +27,19 @@ export function useValveControl(
         servoIndex: mapping.servoIndex,
         action: targetState === 'OPEN' ? ValveCommandType.OPEN : ValveCommandType.CLOSE,
       };
-      void sendCommand(command);
+      const success = await sendCommand(command);
+      if (!success) return;
       setValves((prev) =>
-        prev.map((v) => (v.id === valveId ? { ...v, state: targetState } : v))
+        prev.map((v) =>
+          v.id === valveId
+            ? {
+                ...v,
+                state: targetState === 'OPEN' ? 'OPENING' : 'CLOSING',
+                lsOpen: false,
+                lsClosed: false,
+              }
+            : v
+        )
       );
     },
     [config, sendCommand, valves]

--- a/src/utils/sensorParser.ts
+++ b/src/utils/sensorParser.ts
@@ -14,9 +14,9 @@ export function parseSensorData(raw: string): ParsedSensorData {
     const [key, rawValue] = part.split(':');
     if (!key || !rawValue) return;
     const value = rawValue.trim();
-    const match = key.match(/^V(\d)_LS_(OPEN|CLOSED)$/);
+    const match = key.match(/^V(\d+)_LS_(OPEN|CLOSED)$/);
     if (match) {
-      const valveId = parseInt(match[1], 10);
+      const valveId = parseInt(match[1], 10) + 1;
       const lsType = match[2];
       const lsValue = value === '1';
       if (!valves[valveId]) valves[valveId] = {};


### PR DESCRIPTION
## Summary
- Align limit switch parsing with 1-based valve IDs and support multi-digit valves
- Wait for valve commands to complete before updating state and finalize on limit switch feedback
- Quit on configuration load failure and disable emergency checks when configuration is missing

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689824f6a09c832fb6b902d5d62b3d77