### PR TITLE
Remove npm proxy configuration file

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-# Use environment variables for proxy configuration if defined
-proxy=${HTTP_PROXY}
-https-proxy=${HTTPS_PROXY}


### PR DESCRIPTION
## Summary
- delete `.npmrc` so npm uses environment or default network settings instead of forcing proxy

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals")*

------
https://chatgpt.com/codex/tasks/task_e_6898411d9f7c832f8d3b9e70c21b8f31