### PR TITLE
feat: implement serial handshake and raw sequence commands

### DIFF
--- a/arduino_mega_code/arduino_mega_code.ino
+++ b/arduino_mega_code/arduino_mega_code.ino
@@ -75,7 +75,18 @@ void loop() {
   const unsigned long now = millis(); // [최적화] loop 내 공용 시간값
 
   if (Serial.available() > 0) {
-    handleValveCommand();
+    char c = Serial.peek();
+    if (c == 'H') {
+      String line = Serial.readStringUntil('\n');
+      line.trim();
+      if (line == "HELLO") {
+        Serial.println(F("READY"));
+      }
+    } else if (c == 'V') {
+      handleValveCommand();
+    } else {
+      Serial.readStringUntil('\n'); // Unknown command flush
+    }
   }
 
   // 루프당 1회 스위치 스냅샷

--- a/src/sequences.json
+++ b/src/sequences.json
@@ -1,31 +1,30 @@
 {
   "Pre-launch Check": [
     {
-      "message": "Sending command: PRELAUNCH_CHECK_START",
+      "message": "Opening valve 0",
       "delay": 500,
-      "command": "SEQ_PRELAUNCH_START"
+      "commands": ["V,0,O"]
     }
   ],
   "Ignition Sequence": [
     {
-      "message": "Sending command: IGNITION_SEQUENCE_START",
+      "message": "Opening valves 1 and 2",
       "delay": 500,
-      "command": "SEQ_IGNITION_START"
+      "commands": ["V,1,O", "V,2,O"]
     }
   ],
   "System Purge": [
     {
-      "message": "Sending command: SYSTEM_PURGE",
+      "message": "Closing all valves",
       "delay": 500,
-      "command": "SEQ_PURGE"
+      "commands": ["V,0,C", "V,1,C", "V,2,C", "V,3,C", "V,4,C", "V,5,C", "V,6,C"]
     }
   ],
   "Emergency Shutdown": [
     {
-      "message": "Sending command: EMERGENCY_SHUTDOWN",
+      "message": "Emergency shutdown: close all valves",
       "delay": 100,
-      "command": "SEQ_SHUTDOWN"
+      "commands": ["V,0,C", "V,1,C", "V,2,C", "V,3,C", "V,4,C", "V,5,C", "V,6,C"]
     }
   ]
 }
-


### PR DESCRIPTION
## Summary
- add HELLO/READY handshake to Arduino firmware
- send raw valve commands from sequence manager
- define sequences with low-level commands

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find module '@next/eslint-plugin-next')

------
https://chatgpt.com/codex/tasks/task_e_68984fe82fb4832f852e3222c4369959